### PR TITLE
Jenkins Android builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node ("android") {
     stage('Build Android') {
         sh 'echo sdk.dir=/opt/android-sdk > local.properties'
         dir('android') {
-            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/sdk-version-fixes']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: '']], userRemoteConfigs: [[url: 'https://github.com/BenjaminAmos/DestSolAndroid.git']]]
+            checkout scm: [$class: 'GitSCM', branches: [[name: '*/master']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/MovingBlocks/DestSolAndroid.git']]]
         }
         sh './gradlew --console=plain :android:assembleDebug'
         archiveArtifacts 'android/build/outputs/apk/debug/android-debug.apk'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-node ("default-java || heavy-java") {
+node ("android") {
     stage('Checkout') {
         echo "Going to check out the things !"
         checkout scm
@@ -20,6 +20,18 @@ node ("default-java || heavy-java") {
         recordIssues tool: findBugs(pattern: '**/build/reports/findbugs/*.xml', useRankAsPriority: true)
         recordIssues tool: pmdParser(pattern: '**/build/reports/pmd/*.xml')
         recordIssues tool: taskScanner(includePattern: '**/*.java,**/*.groovy,**/*.gradle', lowTags: 'WIBNIF', normalTags: 'TODO', highTags: 'ASAP')
+    }
+    stage('Build Android') {
+        sh 'echo sdk.dir=/opt/android-sdk > local.properties'
+        dir('android') {
+            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/sdk-version-fixes']], extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: '']], userRemoteConfigs: [[url: 'https://github.com/BenjaminAmos/DestSolAndroid.git']]]
+        }
+        sh './gradlew --console=plain :android:assembleDebug'
+        archiveArtifacts 'android/build/outputs/apk/debug/android-debug.apk'
+    }
+    stage('Record Android') {
+       sh './gradlew --console=plain :android:lint'
+       recordIssues tool: androidLintParser(pattern: 'android/build/reports/lint-results.xml')
     }
     stage('Notify') {
         withCredentials([string(credentialsId: 'destsolDiscordWebhook', variable: 'WEBHOOK')]) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Destination Sol! :-)
Please fill in some brief details below about the PR.
If it contains source code please make sure to do everything in the pre pull request checklist first.
If you add unit tests we'll love you forever! -->

# Description
This pull request adds building Android APKs and running Android Lint to the `Jenkinsfile`.

# Testing
*You will need a working Jenkins environment to test this.*
## Set-up
Create a new agent in Jenkins using the [`android-agent`](https://github.com/BenjaminAmos/JenkinsAndroidSDKAgent) container image. Give it a label of `android`. Use the template below as an example.
```yaml
- containers:
  - args: "^${computer.jnlpmac} ^${computer.name}"
    image: "android-agent"
    livenessProbe:
      failureThreshold: 0
      initialDelaySeconds: 0
      periodSeconds: 0
      successThreshold: 0
      timeoutSeconds: 0
    name: "jnlp"
    resourceLimitCpu: "512m"
    resourceLimitMemory: "2Gi" # Adjust this to suit your environment. Android builds tend to perform better with more memory
    resourceRequestCpu: "512m"
    resourceRequestMemory: "512Mi" # Adjust this to suit your environment. Android builds tend to perform better with more memory
    workingDir: "/home/jenkins/agent"
  id: "<your_id>"
  label: "android"
  name: "android-agent"
  serviceAccount: "jenkins"
  yamlMergeStrategy: "override"
```
## Building
Run the build using the updated `Jenkinsfile`.

# Notes
- Rather than using separate containers and additional resources to build Android and desktop seperately, both builds are performed within the same container, since the requirements for Android are a superset of those for desktop.
- This currently depends on MovingBlocks/DestSolAndroid#23